### PR TITLE
Use expose instead of ports for MySQL and Redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       MYSQL_USER: '${DB_USERNAME}'
       MYSQL_PASSWORD: '${DB_PASSWORD}'
       MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
-    ports:
+    expose:
       - 3306
     restart: unless-stopped
     command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8 --collation-server=utf8_general_ci
@@ -132,7 +132,7 @@ services:
     image: redis:6.0-alpine
     volumes:
       - ./data/redis/:/data
-    ports:
+    expose:
       - 6379
     networks:
       - standardnotes_standalone


### PR DESCRIPTION
Use expose instead of ports for mysql and redis in docker-compose.yml file. With this change, both MySQL and Redis will only be accessible to linked services. I have successfully tested this on my system.

Closes https://github.com/standardnotes/standalone/issues/22