### PR TITLE
Update api-gateway.env.sample

### DIFF
--- a/docker/api-gateway.env.sample
+++ b/docker/api-gateway.env.sample
@@ -1,10 +1,10 @@
-LOG_LEVEL="info"
-NODE_ENV="production"
-VERSION="local"
+LOG_LEVEL=info
+NODE_ENV=production
+VERSION=local
 
 NEW_RELIC_ENABLED=false
 NEW_RELIC_APP_NAME="API Gateway"
 NEW_RELIC_NO_CONFIG_FILE=true
 
-SYNCING_SERVER_JS_URL="http://syncing-server-js:3000"
-AUTH_SERVER_URL="http://auth:3000"
+SYNCING_SERVER_JS_URL=http://syncing-server-js:3000
+AUTH_SERVER_URL=http://auth:3000


### PR DESCRIPTION
Removed double quotes that were causing problems in my Standalone setup.