### PR TITLE
Add docker compose check

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -9,8 +9,7 @@ if [ "$?" -ne "0" ]; then
 fi
 
 DOCKER_COMPOSE_COMMAND="docker compose"
-_=$($DOCKER_COMPOSE_COMMAND > /dev/null 2>&1)
-if [ "$?" -ne "0" ]; then
+if ! $DOCKER_COMPOSE_COMMAND > /dev/null 2>&1; then
   DOCKER_COMPOSE_COMMAND="docker-compose"
 fi
 

--- a/server.sh
+++ b/server.sh
@@ -9,6 +9,7 @@ if [ "$?" -ne "0" ]; then
 fi
 
 DOCKER_COMPOSE_COMMAND="docker compose"
+_=$($DOCKER_COMPOSE_COMMAND > /dev/null 2>&1)
 if [ "$?" -ne "0" ]; then
   DOCKER_COMPOSE_COMMAND="docker-compose"
 fi


### PR DESCRIPTION
Introduces check of `docker compose` subcommand. If the subcommand does not exist (error code != 0),
then the script will fallback to legacy `docker-compose`.

Tested on Ubuntu 20.04:

```console
$ docker --version
Docker version 20.10.12, build e91ed57
$ docker-compose --version
docker-compose version 1.29.2, build unknown
```

Fixes #60.