### PR TITLE
Remove `function` keyword, fix redirection

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -42,7 +42,7 @@ compareLineCount() {
   if [ "$FILES_ENV_FILE_SAMPLE_LINES" -ne "$FILES_ENV_FILE_LINES" ]; then echo "The docker/files.env file contains different amount of lines than docker/files.env.sample. This may be caused by the fact that there is a new environment variable to configure. Please update your environment file and try again." && exit 1; fi
 }
 
-function cleanup {
+cleanup() {
   local output_logs=$1
   if [ $output_logs == 1 ]
   then
@@ -51,13 +51,13 @@ function cleanup {
   fi
 }
 
-function waitForServices {
+waitForServices() {
   attempt=0
   while [ $attempt -le 180 ]; do
       attempt=$(( $attempt + 1 ))
       echo "# Waiting for all services to be up (attempt: $attempt) ..."
       result=$($DOCKER_COMPOSE_COMMAND logs api-gateway)
-      if grep -q 'Server started on port' <<< $result ; then
+      if echo "$result" | grep -q 'Server started on port' ; then
           sleep 2 # for warmup
           echo "# All services are up!"
           break


### PR DESCRIPTION
Lines 45 and 54 used `function` keyword, which is not used in prior function declarations. Line 60 threw a syntax error for unexpected redirection, changed `<<<` operator to use echo and a pipe.